### PR TITLE
Example of Terraform Using the terraform-provider-multipass

### DIFF
--- a/Example/README.md
+++ b/Example/README.md
@@ -36,7 +36,7 @@ Terraform Module
 
 Module Configuration
 ----------------------
-`resource "multipass_instance" "multipass_vm" {
+resource "multipass_instance" "multipass_vm" {
     count           = var.instance_count
     cloudinit_file  = "${path.module}/user_data.cfg"
     name            = vm.name
@@ -45,7 +45,7 @@ Module Configuration
     disk            = var.disks
     image           = var.image_name
 }
-`
+
 ## running the terraform plan
 
 - cd into the main root directory

--- a/Example/README.md
+++ b/Example/README.md
@@ -1,55 +1,54 @@
-Example of the use of The Terraform Provider for Multipass Hypervisor.
-------------------------------------------------------------------------------------------
- Url - https://registry.terraform.io/providers/larstobi/multipass/1.4.2
- By - Lars Tobias Skjong-Børsting
+# Example of Using the Terraform Provider for Multipass Hypervisor
 
- Multipass Hypervisor created by Cononical [Ubuntu] 
- Url - https://multipass.run/
+**URL:** [Terraform Provider for Multipass Hypervisor](https://registry.terraform.io/providers/larstobi/multipass/1.4.2)  
+**Author:** Lars Tobias Skjong-Børsting
 
- Terraform example provided by Robert Weaver
+Multipass Hypervisor created by Canonical [Ubuntu]  
+**URL:** [Multipass](https://multipass.run/)
 
-What is this Example
----------------------
+Terraform example provided by Robert Weaver
 
-This Terraform Module will create 2 example VM's within the multipass hypervisor
-And will use the cloudinit to install the below package on each of the two servers apon bootup
-As well as ensuringin the server is updated, and SSH keys are installed. 
+## What is this Example
 
-Packages to be installed. 
----------------------------
+This Terraform module will create 2 example VMs within the Multipass hypervisor and will use cloud-init to install the following packages on each of the two servers upon bootup, as well as ensuring that the server is updated and SSH keys are installed.
+
+Packages to be installed:
 - Apache2
 - tmux
-- nmon 
+- nmon
 
-Terraform Module
------------------------
+## Terraform Module Structure
 
-── README.md                       < This Readme>
-├── main.tf                             < main calling module>  
-├── multipass_module             < This is the main module folder>
-│   ├── main.tf                  < Main terraform Module >
-│   ├── provider.tf              < Link to provider in the main root folder>
-│   └── vars.tf                  < Variables passed to the main multipass module> 
-├── provider.tf                  < Main provider for multipass version 1.4.2>
-├── user_data.cfg                < Bootstrap installation of packages , ssh keys and upgrade of VM>
-└── variables.tf                 < Variables used by the module , and default settings>
+| File/Folder                 | Description                                     |
+|-----------------------------|-------------------------------------------------|
+| README.md                   | This README                                    |
+| main.tf                      | Main calling module                            |
+| multipass_module/           | Main module folder                             |
+| multipass_module/main.tf     | Main Terraform module                          |
+| multipass_module/provider.tf | Link to the provider in the main root folder   |
+| multipass_module/vars.tf     | Variables passed to the main Multipass module  |
+| provider.tf                 | Main provider for Multipass version 1.4.2     |
+| user_data.cfg               | Bootstrap installation of packages, SSH keys, and VM upgrade |
+| variables.tf                | Variables used by the module and default settings |
 
-Module Configuration
-----------------------
+
+## Module Configuration
+
+```hcl
 resource "multipass_instance" "multipass_vm" {
-    count           = var.instance_count
-    cloudinit_file  = "${path.module}/user_data.cfg"
-    name            = vm.name
-    cpus            = var.cpus
-    memory          = var.memory
-    disk            = var.disks
-    image           = var.image_name
-}
+    count          = var.instance_count
+    cloudinit_file = "${path.module}/user_data.cfg"
+    name           = var.vm_name
+    cpus           = var.cpus
+    memory         = var.memory
+    disk           = var.disks
+    image          = var.image_name
+} ```
 
-## running the terraform plan
+## Running the Terraform Plan
 
-- cd into the main root directory
-- terraform init
-- terraform validate
-- terraform plan
-- terraform apply  < answer yes to proceed >
+    Change directory to the main root directory.
+    Run terraform init.
+    Run terraform validate.
+    Run terraform plan.
+    Run terraform apply (answer yes to proceed).

--- a/Example/README.md
+++ b/Example/README.md
@@ -1,0 +1,55 @@
+Example of the use of The Terraform Provider for Multipass Hypervisor.
+------------------------------------------------------------------------------------------
+ Url - https://registry.terraform.io/providers/larstobi/multipass/1.4.2
+ By - Lars Tobias Skjong-Børsting
+
+ Multipass Hypervisor created by Cononical [Ubuntu] 
+ Url - https://multipass.run/
+
+ Terraform example provided by Robert Weaver
+
+What is this Example
+---------------------
+
+This Terraform Module will create 2 example VM's within the multipass hypervisor
+And will use the cloudinit to install the below package on each of the two servers apon bootup
+As well as ensuringin the server is updated, and SSH keys are installed. 
+
+Packages to be installed. 
+---------------------------
+- Apache2
+- tmux
+- nmon 
+
+Terraform Module
+-----------------------
+
+── README.md                       < This Readme>
+├── main.tf                             < main calling module>  
+├── multipass_module             < This is the main module folder>
+│   ├── main.tf                  < Main terraform Module >
+│   ├── provider.tf              < Link to provider in the main root folder>
+│   └── vars.tf                  < Variables passed to the main multipass module> 
+├── provider.tf                  < Main provider for multipass version 1.4.2>
+├── user_data.cfg                < Bootstrap installation of packages , ssh keys and upgrade of VM>
+└── variables.tf                 < Variables used by the module , and default settings>
+
+Module Configuration
+----------------------
+`resource "multipass_instance" "multipass_vm" {
+    count           = var.instance_count
+    cloudinit_file  = "${path.module}/user_data.cfg"
+    name            = vm.name
+    cpus            = var.cpus
+    memory          = var.memory
+    disk            = var.disks
+    image           = var.image_name
+}
+`
+## running the terraform plan
+
+- cd into the main root directory
+- terraform init
+- terraform validate
+- terraform plan
+- terraform apply  < answer yes to proceed >

--- a/Example/main.tf
+++ b/Example/main.tf
@@ -1,0 +1,12 @@
+module "multipass_vm" {
+  source = "./multipass_module"
+
+  instance_count = var.instance_count
+  user_data      = "${path.module}/user_data.cfg"
+  name_prefix    = "vmtf"
+  name           = var.name
+  image_name     = var.image_name
+  cpus           = var.cpus
+  memory         = var.memory
+  disks          = var.disks
+}

--- a/Example/multipass_module/main.tf
+++ b/Example/multipass_module/main.tf
@@ -1,0 +1,10 @@
+
+resource "multipass_instance" "multipass_vm" {
+  count  = var.instance_count
+  cloudinit_file  = var.user_data
+  name   = "${var.name_prefix}-${var.name}-ubuntu-${count.index + 1}"
+  cpus   = var.cpus
+  memory = var.memory
+  disk   = var.disks
+  image  = var.image_name
+}

--- a/Example/multipass_module/provider.tf
+++ b/Example/multipass_module/provider.tf
@@ -1,0 +1,1 @@
+../provider.tf

--- a/Example/multipass_module/vars.tf
+++ b/Example/multipass_module/vars.tf
@@ -1,0 +1,35 @@
+variable "user_data" {
+  type    = string
+}
+
+variable "name" {
+  type    = string
+}
+
+variable "image_name" {
+    type    = string
+}
+
+variable "cpus" {
+    type    = number
+}
+
+variable "memory" {
+    type    = string
+}
+
+variable "disks" {
+    type     = string
+}
+
+variable "instance_count" {
+  description = "Number of instances to create"
+  type        = number
+  default     = 1
+}
+
+variable "name_prefix" {
+  description = "Instance name prefix"
+  type        = string
+  default     = "instance"
+}

--- a/Example/provider.tf
+++ b/Example/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    multipass = {
+      source = "larstobi/multipass"
+      version = "1.4.2"
+    }
+  }
+}

--- a/Example/user_data.cfg
+++ b/Example/user_data.cfg
@@ -1,0 +1,18 @@
+package_update: true
+package_upgrade: true
+
+users:
+- name: 'ubuntu'
+  groups: users,adm,dialout,audio,netdev,video,plugdev,cdrom,games,input,gpio,spi,i2c,render,sudo
+  shell: /bin/bash
+  lock_passwd: true
+  ssh_authorized_keys:
+    - 'ssh-rsa < add your ssh pubulic key of a connecting machine >'
+
+ssh_deletekeys: false
+packages:
+- apache2
+- tmux
+- vim
+- wget
+- nmon

--- a/Example/variables.tf
+++ b/Example/variables.tf
@@ -1,0 +1,46 @@
+variable "user_data" {
+  description = "cloudinit_file that contains bootstrap provision commands"
+  type    = string
+  default = "./user_data"
+}
+variable "name" {
+  description = "Name of the VM your creating"
+  type    = string
+  default = "dev"
+}
+
+variable "image_name" {
+  description = "ubuntu image name default jammy Lts"
+  type    = string
+  default = "jammy"
+}
+
+variable "cpus" {
+  description = "virtual cpu count"
+  type    = number
+  default = 4
+}
+
+variable "memory" {
+  description = "virtual Vm memory allocation"
+  type    = string
+  default = "4G"
+}
+
+variable "disks" {
+  description = "Thin provisioned disk size"
+    type    = string
+    default = "20G"
+}
+
+variable "instance_count" {
+  description = "Number of instances to create"
+  type        = number
+  default     = 2
+}
+
+variable "name_prefix" {
+  description = "Instance name prefix"
+  type        = string
+  default     = "instance"
+}


### PR DESCRIPTION
Added folder 'Example' This folder consists of terraform .tf file's to demonstrate how to use the terraform provider multipass. This also includes a simple cloudinit_file that will be used during bootstrap of the new virtual machines created by the terraform module.
 The terraform module , will allow for multiple 'vm's' to be created. Install apache2 , tmux and nmon as examples as well a upgrade the nodes.
 If you require to add a connecting servers ssh key this can be inserted into the 'user_data' file.

